### PR TITLE
allow Client with openssl+proxy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ webpki = { version = "0.21.0", optional = true }
 webpki-roots = { version = "^0.19", optional = true }
 
 [features]
-default = ["socks", "webpki", "webpki-roots", "rustls"]
+default = ["proxy", "use-rustls"]
 minimal = []
 debug-calls = []
 proxy = ["socks"]

--- a/src/client.rs
+++ b/src/client.rs
@@ -11,8 +11,7 @@ use types::*;
 /// [`RawClient`](client/struct.RawClient.html) and provides a more user-friendly
 /// constructor that can choose the right backend based on the url prefix.
 ///
-/// **This is only available with the `default` features.**
-#[cfg(feature = "default")]
+/// **This is available only with the `default` features, or if `proxy` and one ssl implementation are enabled**
 pub enum Client {
     #[doc(hidden)]
     TCP(RawClient<ElectrumPlaintextStream>),
@@ -32,7 +31,6 @@ macro_rules! impl_inner_call {
     }
 }
 
-#[cfg(feature = "default")]
 impl Client {
     /// Generic constructor that supports multiple backends and, optionally, a socks5 proxy.
     ///
@@ -70,7 +68,6 @@ impl Client {
     }
 }
 
-#[cfg(feature = "default")]
 impl ElectrumApi for Client {
     #[inline]
     fn batch_call(&self, batch: Batch) -> Result<Vec<serde_json::Value>, Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,13 @@ extern crate webpki_roots;
 
 mod api;
 mod batch;
+
+#[cfg(any(
+    all(feature = "proxy", feature = "use-openssl"),
+    all(feature = "proxy", feature = "use-rustls")
+))]
 pub mod client;
+
 pub mod raw_client;
 mod stream;
 mod types;


### PR DESCRIPTION
without these changes you can't for example run:

`cargo run --example ssl --no-default-features --features use-openssl --features proxy`

because `Client` is built only with with default features, but having the combination of SSL and proxy is enough for the client to run.

to avoid repeating the cfg before Client, impl Client and impl ElectrumApi the cfg has been moved at module level

it also change the Cargo toml to recall features instead of repeating deps for the default feature